### PR TITLE
Permit special charatere usage

### DIFF
--- a/templates/grant.erb
+++ b/templates/grant.erb
@@ -1,8 +1,8 @@
 # File managed by Puppet
 
 <% if mysql_db != "*" then %>
-    CREATE DATABASE IF NOT EXISTS <%= mysql_db %> ;
+    CREATE DATABASE IF NOT EXISTS `<%= mysql_db %>` ;
 <% end %>
-GRANT <%= mysql_privileges %> ON <%= mysql_db %>.* TO '<%= mysql_user %>'@'<%= mysql_host %>' IDENTIFIED BY '<%= mysql_password %>';
+GRANT <%= mysql_privileges %> ON `<%= mysql_db %>`.* TO '<%= mysql_user %>'@'<%= mysql_host %>' IDENTIFIED BY '<%= mysql_password %>';
 FLUSH PRIVILEGES ;
 


### PR DESCRIPTION
If you want to use character like dash in database name you have to enclose this one with back quote (`).

This PR correct this issue.
