### PR TITLE
Fixed wildcard database and added some extra options to grant.pp, added tests.

### DIFF
--- a/manifests/grant.pp
+++ b/manifests/grant.pp
@@ -1,13 +1,57 @@
+# Define mysql::grant
+#
+# This define adds a grant to the MySQL server. It creates a file with the
+# grant statement and then applies it.
+#
+# Supported arguments:
+# $mysql_db             - The database to apply the grant to. 
+#                         If not set, defaults to == $title
+#                         It supports SQL wildcards (%), ie: 'somedatab%'.
+#                         The special value '*' means 'ALL DATABASES'
+# $mysql_user           - User to grant the permissions to.
+# $mysql_password       - Plaintext password for the user.
+# $mysql_create_db      - If you want a $mysql_db database created or not.
+#                         Default: true.
+# $mysql_privileges     - Privileges to grant to the user.
+#                         Defaults to 'ALL'
+# $mysql_host           - Host where the user can connect from. Accepts SQL wildcards.
+#                         Default: 'localhost'
+# $mysql_grant_filepath - Path where the grant files will be stored.
+#                         Default: '/root/puppet-mysql'
+
 define mysql::grant (
-  $mysql_db,
+  $mysql_db = '',
   $mysql_user,
   $mysql_password,
+  $mysql_create_db      = true,
   $mysql_privileges     = 'ALL',
   $mysql_host           = 'localhost',
   $mysql_grant_filepath = '/root/puppet-mysql'
   ) {
 
   require mysql
+
+  $dbname = $mysql_db ? {
+   ''      => $name,
+   default => $mysql_db,
+  } 
+
+  # Check for wildcards
+  $real_db = $dbname ? {
+    /^(\*|%)$/ => '*',
+    default   => "`${dbname}`",
+  }
+
+  $mysql_grant_file = $dbname ? {
+    /^(\*|%)$/ => "mysqlgrant-${mysql_user}-${mysql_host}-all.sql",
+    default   => "mysqlgrant-${mysql_user}-${mysql_host}-${dbname}.sql",
+  }
+
+  # If dbname has a wildcard, we don't want to create anything
+  $bool_mysql_create_db = $dbname ? {
+    /(\*|%)/ => false,
+    default => any2bool($mysql_create_db)
+  }
 
   if (!defined(File[$mysql_grant_filepath])) {
     file { $mysql_grant_filepath:
@@ -17,12 +61,6 @@ define mysql::grant (
       group  => root,
       mode   => '0700',
     }
-  }
-
-  if ($mysql_db == '*') {
-    $mysql_grant_file = "mysqlgrant-${mysql_user}-${mysql_host}-all.sql"
-  } else {
-    $mysql_grant_file = "mysqlgrant-${mysql_user}-${mysql_host}-${mysql_db}.sql"
   }
 
   file { $mysql_grant_file:

--- a/spec/defines/grant_spec.rb
+++ b/spec/defines/grant_spec.rb
@@ -1,0 +1,79 @@
+require "#{File.join(File.dirname(__FILE__),'..','spec_helper.rb')}"
+
+describe 'mysql::grant' do
+
+  let(:title) { 'mysql::grant' }
+  let(:node) { 'rspec.example42.com' }
+  let(:facts) { { :ipaddress => '10.42.42.42', :grants_file => '/etc/mysql/grant.local', :concat_basedir => '/var/lib/puppet/concat'} }
+
+  describe 'Test grant all privileges on all databases (*). Should not create the databases' do
+    let(:params) { { :name    => 'sample2',
+                     :mysql_db => '*',
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-all.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+GRANT ALL ON *.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+
+  describe 'Test grant all privileges on all databases (%). Should not create the databases' do
+    let(:params) { { :name    => 'sample2',
+                     :mysql_db => '%',
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-all.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+GRANT ALL ON *.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+
+  describe 'Test grant single privilege on single database. Should not create the databases' do
+    let(:params) { { :name    => 'sample3',
+                     :mysql_user => 'someuser',
+                     :mysql_create_db => false,
+                     :mysql_privileges => 'USAGE',
+                     :mysql_host => 'somehost',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-somehost-sample3.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+GRANT USAGE ON `sample3`.* TO 'someuser'@'somehost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+
+  describe 'Test grant all privileges on a single database. Should create the database' do
+    let(:params) { { :name    => 'sample4',
+                     :mysql_db => 'sample4_db',
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-sample4_db.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+CREATE DATABASE IF NOT EXISTS `sample4_db`;
+GRANT ALL ON `sample4_db`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+
+  describe 'Test grant all privileges on a single database. Should not create the database' do
+    let(:params) { { :name    => 'sample5',
+                     :mysql_db => 'sample5_db',
+                     :mysql_create_db => false,
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-sample5_db.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+GRANT ALL ON `sample5_db`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+
+  describe 'Test grant all privileges on many databases using SQL wilcards. Should not create databases' do
+    let(:params) { { :name    => 'sample6',
+                     :mysql_db => 'sample6_db%',
+                     :mysql_create_db => true,
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-sample6_db%.sql').with_content("# This file is managed by Puppet. DO NOT EDIT.
+GRANT ALL ON `sample6_db%`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
+end

--- a/templates/grant.erb
+++ b/templates/grant.erb
@@ -1,8 +1,6 @@
-# File managed by Puppet
-
-<% if @mysql_db != "*" then %>
-    CREATE DATABASE IF NOT EXISTS `<%= @mysql_db %>` ;
-<% end %>
-GRANT <%= @mysql_privileges %> ON `<%= @mysql_db %>`.* TO '<%= @mysql_user %>'@'<%= @mysql_host %>' IDENTIFIED BY '<%= @mysql_password %>';
+# This file is managed by Puppet. DO NOT EDIT.
+<% if @bool_mysql_create_db -%>
+CREATE DATABASE IF NOT EXISTS <%= @real_db %>;
+<% end -%>
+GRANT <%= @mysql_privileges %> ON <%= @real_db %>.* TO '<%= @mysql_user %>'@'<%= @mysql_host %>' IDENTIFIED BY '<%= @mysql_password %>';
 FLUSH PRIVILEGES ;
-


### PR DESCRIPTION
Alessandro,

grant.pp had an error when using '*' as a wildcard. It passed the asterisk literal to the grant command, but in SQL the wildcard is '%', so the grant didn't do what expected. Corrected this.

Also added:
- Extra controls to be able to specify grants for wilcard databases (something like 'datab%').
- Added extra controls when specifying wilcards, so no database creation is attempted in these cases.
- Add extra parameter to be able to specify if you want to create or not the database.
- Added tests.

Please take a look at the changes and let me know if something is wrong

Regards,

   Javier
