### PR TITLE
Added a new parameter for mysql_db_create_options to grant.pp

### DIFF
--- a/manifests/grant.pp
+++ b/manifests/grant.pp
@@ -38,7 +38,10 @@ define mysql::grant (
    default => $mysql_db,
   }
   
-  $real_db_create_options = $mysql_db_create_options
+  $real_db_create_options = $mysql_db_create_options ? {
+    ''      => '',
+    default => " $mysql_db_create_options",
+  }
 
   # Check for wildcards
   $real_db = $dbname ? {

--- a/spec/defines/grant_spec.rb
+++ b/spec/defines/grant_spec.rb
@@ -76,4 +76,18 @@ GRANT ALL ON `sample6_db%`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepasswo
 FLUSH PRIVILEGES ;
 ") }
   end
+  
+  describe 'Test grant on a single db with create options' do
+    let(:params) { { :name    => 'sample7',
+                     :mysql_db => 'sample7_db',
+                     :mysql_db_create_options => 'character set utf8',
+                     :mysql_user => 'someuser',
+                     :mysql_password => 'somepassword', } }
+    it { should contain_file('mysqlgrant-someuser-localhost-sample7_db.sql').with_content(
+"# This file is managed by Puppet. DO NOT EDIT.
+CREATE DATABASE IF NOT EXISTS `sample7_db` character set utf8;
+GRANT ALL ON `sample7_db`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
+FLUSH PRIVILEGES ;
+") }
+  end
 end

--- a/templates/grant.erb
+++ b/templates/grant.erb
@@ -1,6 +1,6 @@
 # This file is managed by Puppet. DO NOT EDIT.
 <% if @bool_mysql_create_db -%>
-CREATE DATABASE IF NOT EXISTS <%= @real_db %> <%= @real_db_create_options %>;
+CREATE DATABASE IF NOT EXISTS <%= @real_db %><%= @real_db_create_options %>;
 <% end -%>
 GRANT <%= @mysql_privileges %> ON <%= @real_db %>.* TO '<%= @mysql_user %>'@'<%= @mysql_host %>' IDENTIFIED BY '<%= @mysql_password %>';
 FLUSH PRIVILEGES ;


### PR DESCRIPTION
Hi,

I've added a new parameter for mysql_db_create_options (I needed 'character set utf8' on my server). The default is set to '' so the the defined type should remain backward compatible.

Best regards,
jerger
