### PR TITLE
Minor bug correction to grant define.

### DIFF
--- a/manifests/grant.pp
+++ b/manifests/grant.pp
@@ -84,7 +84,7 @@ define mysql::grant (
     default => "mysql --defaults-file=/root/.my.cnf -uroot < ${mysql_grant_filepath}/${mysql_grant_file}",
   }
 
-  exec { "mysqlgrant-${mysql_user}-${mysql_host}-${mysql_db}":
+  exec { "mysqlgrant-${mysql_user}-${mysql_host}-${dbname}":
     command     => $exec_command,
     require     => Service['mysql'],
     subscribe   => File[$mysql_grant_file],

--- a/spec/defines/grant_spec.rb
+++ b/spec/defines/grant_spec.rb
@@ -7,7 +7,8 @@ describe 'mysql::grant' do
   let(:facts) { { :ipaddress => '10.42.42.42', :grants_file => '/etc/mysql/grant.local', :concat_basedir => '/var/lib/puppet/concat'} }
 
   describe 'Test grant all privileges on all databases (*). Should not create the databases' do
-    let(:params) { { :name    => 'sample2',
+    let(:facts) { { :mysql_root_password => 'rootpassword' } }
+    let(:params) { { :name    => 'sample1',
                      :mysql_db => '*',
                      :mysql_user => 'someuser',
                      :mysql_password => 'somepassword', } }
@@ -15,9 +16,11 @@ describe 'mysql::grant' do
 GRANT ALL ON *.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
 FLUSH PRIVILEGES ;
 ") }
+    it { should contain_exec('mysqlgrant-someuser-localhost-*').with_command('mysql --defaults-file=/root/.my.cnf -uroot < /root/puppet-mysql/mysqlgrant-someuser-localhost-all.sql') }
   end
 
   describe 'Test grant all privileges on all databases (%). Should not create the databases' do
+    let(:facts) { { :mysql_root_password => 'rootpassword' } }
     let(:params) { { :name    => 'sample2',
                      :mysql_db => '%',
                      :mysql_user => 'someuser',
@@ -26,6 +29,7 @@ FLUSH PRIVILEGES ;
 GRANT ALL ON *.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
 FLUSH PRIVILEGES ;
 ") }
+    it { should contain_exec('mysqlgrant-someuser-localhost-%').with_command('mysql --defaults-file=/root/.my.cnf -uroot < /root/puppet-mysql/mysqlgrant-someuser-localhost-all.sql') }
   end
 
   describe 'Test grant single privilege on single database. Should not create the databases' do
@@ -39,6 +43,7 @@ FLUSH PRIVILEGES ;
 GRANT USAGE ON `sample3`.* TO 'someuser'@'somehost' IDENTIFIED BY 'somepassword';
 FLUSH PRIVILEGES ;
 ") }
+    it { should contain_exec('mysqlgrant-someuser-somehost-sample3').with_command('mysql -uroot < /root/puppet-mysql/mysqlgrant-someuser-somehost-sample3.sql') }
   end
 
   describe 'Test grant all privileges on a single database. Should create the database' do
@@ -51,6 +56,7 @@ CREATE DATABASE IF NOT EXISTS `sample4_db`;
 GRANT ALL ON `sample4_db`.* TO 'someuser'@'localhost' IDENTIFIED BY 'somepassword';
 FLUSH PRIVILEGES ;
 ") }
+    it { should contain_exec('mysqlgrant-someuser-localhost-sample4_db').with_command('mysql -uroot < /root/puppet-mysql/mysqlgrant-someuser-localhost-sample4_db.sql') }
   end
 
   describe 'Test grant all privileges on a single database. Should not create the database' do


### PR DESCRIPTION
The previous construction caused a race condition where two different grants could get assigned the same file name.

Add tests for these cases.
