### PR TITLE
Changing var use in queryfile.pp from mysql_host to remote_host

### DIFF
--- a/manifests/grant.pp
+++ b/manifests/grant.pp
@@ -130,6 +130,7 @@ define mysql::grant (
       mysql_password => $mysql_password,
       mysql_db       => $mysql_db,
       mysql_host     => $mysql_host,
+      remote_host    => $remote_host,
       subscribe      => Exec["mysqlgrant-${mysql_user}-${nice_mysql_host}-${dbname}"],
     }
   }

--- a/manifests/queryfile.pp
+++ b/manifests/queryfile.pp
@@ -6,7 +6,8 @@ define mysql::queryfile (
   $mysql_user           = '',
   $mysql_password       = '',
   $mysql_host           = '',
-  $mysql_query_filepath = '/root/puppet-mysql'
+  $mysql_query_filepath = '/root/puppet-mysql',
+  $remote_host = '',
   ) {
 
   if ! defined(File[$mysql_query_filepath]) {
@@ -20,9 +21,9 @@ define mysql::queryfile (
     default => "-u ${mysql_user}",
   }
 
-  $arg_mysql_host = $mysql_host ? {
+  $arg_mysql_host = $remote_host ? {
   ''      => '',
-  default => "-h ${mysql_host}",
+  default => "-h ${remote_host}",
   }
 
   $arg_mysql_password = $mysql_password ? {


### PR DESCRIPTION
When specifying '%' as the mysql_host, Puppet runs error out with the following -

Notice: /Stage[main]//Mysql::Grant[db1]/Mysql::Queryfile[mysql_db_init_query_file-%-db1]/Exec[mysqlqueryfile-mysql_db_init_query_file-%-db1]/returns: ERROR 2005 (HY000): Unknown MySQL server host '%' (0)
Error: mysql -u alpha --password="alpha" -h % db1 < /tmp/db1_init.sql && touch /root/puppet-mysql/mysqlqueryfile-mysql_db_init_query_file-%-db1.run returned 1 instead of one of [0]
Error: /Stage[main]//Mysql::Grant[db1]/Mysql::Queryfile[mysql_db_init_query_file-%-db1]/Exec[mysqlqueryfile-mysql_db_init_query_file-%-db1]/returns: change from notrun to 0 failed: mysql -u alpha --password="alpha" -h % db1 < /tmp/db1_init.sql && touch /root/puppet-mysql/mysqlqueryfile-mysql_db_init_query_file-%-db1.run returned 1 instead of one of [0]

The changes below seem to fix that.
