### PR TITLE
mysql: fix test for future parser.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -423,7 +423,7 @@ class mysql (
   }
 
   # The whole mysql configuration directory can be recursively overriden
-  if $mysql::source_dir {
+  if $mysql::source_dir != '' {
     file { 'mysql.dir':
       ensure  => directory,
       path    => $mysql::config_dir,
@@ -439,7 +439,7 @@ class mysql (
 
 
   ### Include custom class if $my_class is set
-  if $mysql::my_class {
+  if $mysql::my_class != '' {
     include $mysql::my_class
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -423,7 +423,7 @@ class mysql (
   }
 
   # The whole mysql configuration directory can be recursively overriden
-  if $mysql::source_dir != '' {
+  if $mysql::source_dir and $mysql::source_dir != '' {
     file { 'mysql.dir':
       ensure  => directory,
       path    => $mysql::config_dir,
@@ -439,7 +439,7 @@ class mysql (
 
 
   ### Include custom class if $my_class is set
-  if $mysql::my_class != '' {
+  if $mysql::my_class and $mysql::my_class != '' {
     include $mysql::my_class
   }
 


### PR DESCRIPTION
Hi Alessandro,
Fixes for future parser.
Not sure if we could (and if it would be preferable to) initialize source_dir and my_class at false or undef in params.pp (as proposed in #65 by @wooziethe), but as I saw equivalent things merged to example42/php I choose to modify the test.
Thanks!